### PR TITLE
Add expanded README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,36 @@
-motorcycleclub
+# MCApp - Motorcycle Club App
+
+MCApp is a full stack web application that combines a Next.js/TypeScript frontend with an ASP.NET Core API backend. The project is organized into separate directories for the frontend UI, backend services, and infrastructure.
+
+## Directory overview
+
+```
+.
+├── app/                # Top‑level Next.js pages
+├── components/         # Reusable React components
+├── hooks/              # Custom React hooks
+├── lib/                # Client-side utility modules
+├── src/
+│   ├── api/            # .NET Web API with EF Core
+│   ├── db/             # Database migration scripts
+│   └── types/          # Shared TypeScript interfaces
+├── infra/              # Bicep template for Azure resources
+├── scripts/            # Project setup scripts
+├── compose.yaml        # Docker Compose for local dev
+└── Dockerfile          # Builds the frontend
+```
+
+The README describes how to run both services using Docker Compose. The frontend is exposed on port `3000` and the API on port `8080`.
 
 ## Running with Docker
 
-This project includes Docker support for both the TypeScript/Next.js frontend and the C# .NET API backend. The setup uses Docker Compose to orchestrate both services.
+This repository includes Docker support for both the TypeScript/Next.js frontend and the C# .NET API backend. The setup uses Docker Compose to orchestrate both services.
 
 ### Requirements
 - Docker and Docker Compose installed
 - No external services (databases, caches) required by default
 
-### Service Versions
+### Service versions
 - **Frontend (ts-app):** Node.js 22.13.1 (slim)
 - **Backend (dotnet-api):** .NET 8.0
 
@@ -16,7 +38,7 @@ This project includes Docker support for both the TypeScript/Next.js frontend an
 - **Frontend (ts-app):** http://localhost:3000
 - **Backend (dotnet-api):** http://localhost:8080 (mapped to container port 80)
 
-### Build and Run
+### Build and run
 From the project root, run:
 
 ```sh
@@ -27,13 +49,21 @@ This will build and start both services:
 - `ts-app` (Next.js frontend) on port 3000
 - `dotnet-api` (.NET backend) on port 8080
 
-### Environment Variables
+### Environment variables
 - No required environment variables are specified by default in the Dockerfiles or compose file.
 - If you need to set environment variables, uncomment the `env_file` lines in `docker-compose.yml` and provide the appropriate `.env` files.
 
-### Special Configuration
+### Special configuration
 - Both services run as non-root users inside their containers for improved security.
 - The frontend service depends on the backend and will wait for it to be available.
 - If you wish to enable HTTPS for the backend, uncomment the relevant port mapping in the compose file.
+
+## Next steps for new contributors
+
+1. **Run locally** – install Docker and start both services with `docker compose up --build` as described above.
+2. **Explore the API** – review `src/api/Controllers/` and the EF Core models to understand available endpoints and authorization logic.
+3. **Investigate the frontend** – look into `components/` and `app/` to see how React components consume the API.
+4. **Check the deployment pipeline** – study the GitHub Actions workflow and `infra/` Bicep template if you plan to deploy to Azure or modify infrastructure.
+5. **Learn more** – if unfamiliar with Next.js, EF Core, or Docker Compose, these technologies are central to development and deployment.
 
 ---


### PR DESCRIPTION
## Summary
- add a README with an overview of MCApp
- document directory structure and Docker workflow
- outline steps for new contributors

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518d595b70832fa704af7ff9f301c4